### PR TITLE
Page component: Adds a new prop for Admin and Content 

### DIFF
--- a/src/lib/Docz.css
+++ b/src/lib/Docz.css
@@ -5185,6 +5185,10 @@ h6 {
     width: 100%;
   }
 
+.page-admin-header-extra {
+  float: right;
+}
+
 .page-content {
   background-color: #fafdfa;
   border-top: solid 1px var(--very-light-pink);

--- a/src/lib/Docz.css
+++ b/src/lib/Docz.css
@@ -5204,6 +5204,11 @@ h6 {
     margin-bottom: 1.625rem;
   }
 
+.page-content .page-content-header{
+    display: flex;
+    justify-content: space-between;
+  }
+
 /* TODO Refactor for better code organization */
 
 .detail {

--- a/src/lib/css/templates/content.pcss
+++ b/src/lib/css/templates/content.pcss
@@ -15,4 +15,9 @@
     line-height: normal;
     margin-bottom: 1.625rem;
   }
+
+  .page-content-header{
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/src/lib/css/templates/page.pcss
+++ b/src/lib/css/templates/page.pcss
@@ -4,7 +4,6 @@
     /* width: 100%; */
     > .page-header {
       padding: 1.625rem 1.875rem;
-
       h1 {
         color: var(--black);
         font-size: 2.25rem;
@@ -32,4 +31,8 @@
     margin: 0;
     width: 100%;
   }
+}
+
+.page-admin-header-extra {
+  float: right;
 }

--- a/src/lib/js/templates/page/Administrative.jsx
+++ b/src/lib/js/templates/page/Administrative.jsx
@@ -5,23 +5,36 @@ import { Grid } from './../../atoms';
 type Props = {
   children: React.Node,
   title: string,
+  /**May add any component next to the header. Should be inside a fragment. */
+  headerComponents?: React.Node,
   description?: string,
 };
 
-export const Administrative = ({ children, title, description }: Props) => (
+export const Administrative = ({ children, title, description, headerComponents }: Props) => (
   <div className='page page-administrative'>
     <div className='page-header'>
       <Grid.Container className='pg-container'>
         <Grid.Row>
           <Grid.Col>
-            <h1>{title}</h1>
-            {
-              description && (
-                <p>{description}</p>
-              )
-            }
+            <div>
+              <div className='page-admin-header'>
+                <h1>{title}</h1>
+                {
+                  description && (
+                    <p>{description}</p>
+                  )
+                }
+            </div>
+          </div>
           </Grid.Col>
           <Grid.Col>
+          {
+            headerComponents && (
+              <div className='page-admin-header-extra'>
+                  <span>{headerComponents}</span>
+              </div>
+              )
+          }
           </Grid.Col>
         </Grid.Row>
       </Grid.Container>

--- a/src/lib/js/templates/page/Content.jsx
+++ b/src/lib/js/templates/page/Content.jsx
@@ -1,18 +1,28 @@
 import * as React from 'react';
+import {Container, Row, Col} from 'react-bootstrap';
 
 type Props = {
   children: React.Node,
   title?: string,
+  extras?: React.Node,
   className?: string,
 }
 
-export const Content = ({ children, className, title }: Props) => (
+
+export const Content = ({ children, className, title, extras }: Props) => (
   <div className={`page-content ${className}`}>
-    {
-      title && (
-        <h2 className='content-title'>{title}</h2>
-      )
-    }
+          <div className='page-content-header'>
+            {
+              title && (
+                <h2 className='content-title'>{title}</h2>
+              )
+            }
+            {
+              extras && (
+                <div className='page-header-right'> {extras} </div>
+              )
+            }
+          </div>
     {children}
   </div>
 );

--- a/src/lib/js/templates/page/Content.jsx
+++ b/src/lib/js/templates/page/Content.jsx
@@ -4,12 +4,13 @@ import {Container, Row, Col} from 'react-bootstrap';
 type Props = {
   children: React.Node,
   title?: string,
-  extras?: React.Node,
+  /**May add any component next to the header. Should be inside a fragment. */
+  headerComponents?: React.Node,
   className?: string,
 }
 
 
-export const Content = ({ children, className, title, extras }: Props) => (
+export const Content = ({ children, className, title, headerComponents }: Props) => (
   <div className={`page-content ${className}`}>
           <div className='page-content-header'>
             {
@@ -18,8 +19,8 @@ export const Content = ({ children, className, title, extras }: Props) => (
               )
             }
             {
-              extras && (
-                <div className='page-header-right'> {extras} </div>
+              headerComponents && (
+                <div className='page-header-right'> {headerComponents} </div>
               )
             }
           </div>

--- a/src/lib/js/templates/page/Page.mdx
+++ b/src/lib/js/templates/page/Page.mdx
@@ -48,7 +48,7 @@ import '@_src_/lib/Docz.css';
         description='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sagittis metus vitae elit lacinia dapibus at sed nibh. In hac habitasse platea dictumst. Etiam condimentum orci justo. Fusce nec augue leo.'
       >
         <Page.Content
-        extras={
+        headerComponents={
           <>
             <Button>First</Button>
             <Button>Second</Button>

--- a/src/lib/js/templates/page/Page.mdx
+++ b/src/lib/js/templates/page/Page.mdx
@@ -8,7 +8,7 @@ import { Playground, Props } from 'docz';
 import { Router } from 'react-router';
 import { createBrowserHistory } from "history";
 
-import { ThemeContext, Page, Sidebar, SidebarContext } from '@cordage_ui';
+import { ThemeContext, Page, Sidebar, SidebarContext, Button } from '@cordage_ui';
 import theme from '@cordage_ui/cordage.json';
 import logo from '@_src_/lib/img/logo.svg';
 import locations from '@_src_/lib/img/icons/locations.svg';
@@ -48,6 +48,12 @@ import '@_src_/lib/Docz.css';
         description='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sagittis metus vitae elit lacinia dapibus at sed nibh. In hac habitasse platea dictumst. Etiam condimentum orci justo. Fusce nec augue leo.'
       >
         <Page.Content
+        extras={
+          <>
+            <Button>First</Button>
+            <Button>Second</Button>
+          </>
+        }
           title='Example title'
         >
           <div>Example text</div>

--- a/src/lib/js/templates/page/Page.mdx
+++ b/src/lib/js/templates/page/Page.mdx
@@ -45,6 +45,11 @@ import '@_src_/lib/Docz.css';
       </SidebarContext.Provider>
       <Page.Administrative
         title='Collections'
+        headerComponents={
+          <>
+            <Button variant='dark'>Edit</Button>
+          </>
+        }
         description='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean sagittis metus vitae elit lacinia dapibus at sed nibh. In hac habitasse platea dictumst. Etiam condimentum orci justo. Fusce nec augue leo.'
       >
         <Page.Content


### PR DESCRIPTION
This pull adds the prop `headerComponent` to both `.Admin ` and  `.Content ` `Page` modules. 

This prop allows new components inside them. Those are fixed in position based on the Zeplin design. Client approved.